### PR TITLE
Close the temp file before sending to s3

### DIFF
--- a/src/main/java/gov/usgs/wma/waterdata/groundwater/BuildRdbFile.java
+++ b/src/main/java/gov/usgs/wma/waterdata/groundwater/BuildRdbFile.java
@@ -85,6 +85,7 @@ public class BuildRdbFile implements Function<RequestObject, ResultObject> {
 			RdbWriter rdbWriter = createRdbWriter(writer).writeHeader();
 			dao.sendDiscreteGroundWater(states, rdbWriter);
 
+			s3bucket.flush();
 			s3bucket.sendS3();
 
 			result.setCount( (int)rdbWriter.getDataRows() );

--- a/src/main/java/gov/usgs/wma/waterdata/groundwater/BuildRdbFile.java
+++ b/src/main/java/gov/usgs/wma/waterdata/groundwater/BuildRdbFile.java
@@ -85,7 +85,6 @@ public class BuildRdbFile implements Function<RequestObject, ResultObject> {
 			RdbWriter rdbWriter = createRdbWriter(writer).writeHeader();
 			dao.sendDiscreteGroundWater(states, rdbWriter);
 
-			s3bucket.flush();
 			s3bucket.sendS3();
 
 			result.setCount( (int)rdbWriter.getDataRows() );

--- a/src/main/java/gov/usgs/wma/waterdata/groundwater/S3Bucket.java
+++ b/src/main/java/gov/usgs/wma/waterdata/groundwater/S3Bucket.java
@@ -34,6 +34,11 @@ public class S3Bucket implements AutoCloseable {
 		return keyName;
 	}
 
+	
+	public void flush() throws IOException {
+		writer.flush();
+	}
+
 	@Override
 	public void close() throws Exception {
 		try {

--- a/src/main/java/gov/usgs/wma/waterdata/groundwater/S3Bucket.java
+++ b/src/main/java/gov/usgs/wma/waterdata/groundwater/S3Bucket.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.zip.GZIPOutputStream;
+import java.lang.RuntimeException;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
@@ -34,11 +35,6 @@ public class S3Bucket implements AutoCloseable {
 		return keyName;
 	}
 
-	
-	public void flush() throws IOException {
-		writer.flush();
-	}
-
 	@Override
 	public void close() throws Exception {
 		try {
@@ -57,6 +53,11 @@ public class S3Bucket implements AutoCloseable {
 	}
 
 	public PutObjectResult sendS3() {
+		try {
+			writer.close();
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to close the temp file before sending to s3.");
+		}
 		AmazonS3 s3 = buildS3();
 		return s3.putObject(bucket, keyName, file);
 	}


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
----------
This flushes the temp file writer before sending to s3 

Description
-----------
A previous commit made to prevent incomplete files from being sent to s3 actually when an exception was thrown had a bug that sent incomplete files because the file buffer was not flushed and the file was not closed.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial