### PR TITLE
'null' is no longer used for null values - empty string instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). (Patch version X.Y.0 is implied if not specified.)
 
 ## [Unreleased](https://github.com/usgs/etl-discrete-groundwater-rdb)
+-   Null fields now write an empty string instead of 'null'
 
 ### Added
 -   Initial Implementation

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ To run tests against local observation Docker database use:
 Observation database: 
 ```.sh
 docker run -p 127.0.0.1:5444:5432/tcp usgswma/wqp_db:etl
+docker run -p 127.0.0.1:5437:5432/tcp usgswma/aqts_capture_db:ci
 ```
 
 Additionally, add an `application.yml` configuration file at the project root (the following is an example):

--- a/src/main/java/gov/usgs/wma/waterdata/groundwater/BuildRdbFile.java
+++ b/src/main/java/gov/usgs/wma/waterdata/groundwater/BuildRdbFile.java
@@ -90,7 +90,7 @@ public class BuildRdbFile implements Function<RequestObject, ResultObject> {
 
 			s3bucket.sendS3();
 
-			result.setCount( (int)rdbWriter.getDataRows() );
+			result.setCount( (int)rdbWriter.getDataRowCount() );
 			result.setMessage("Count is rows written to file: " + s3bucket.getKeyName());
 		} catch (Exception e) {
 			throw new RuntimeException("Error writing RDB file to S3, " + filename, e);

--- a/src/main/java/gov/usgs/wma/waterdata/groundwater/RdbWriter.java
+++ b/src/main/java/gov/usgs/wma/waterdata/groundwater/RdbWriter.java
@@ -38,10 +38,10 @@ public class RdbWriter {
 		initRows();
 	}
 
-	public long getHeaderRows() {
+	public long getHeaderRowCount() {
 		return headerLineCount;
 	}
-	public long getDataRows() {
+	public long getDataRowCount() {
 		return dataLineCount;
 	}
 	protected void initRows() {
@@ -130,16 +130,17 @@ public class RdbWriter {
 	 * entry length. This writes only the given length value
 	 * @param length max number of chars to write
 	 * @param value characters to write, non-string values must be converted.
+	 * @return The trimmed value with nulls converted to empty strings.
 	 */
 	protected String validateValue(int length, String value) {
 		// Trim the value to the proper field length.
-		String trimmedValue = value;
+
 		if (value == null) {
 			value = "";
 		}
 		if (value.length() > length) {
-			trimmedValue = value.substring(0, length);
+			value = value.substring(0, length);
 		}
-		return trimmedValue;
+		return value;
 	}
 }

--- a/src/test/java/gov/usgs/wma/waterdata/groundwater/BuildRdbFileTest.java
+++ b/src/test/java/gov/usgs/wma/waterdata/groundwater/BuildRdbFileTest.java
@@ -57,7 +57,7 @@ class BuildRdbFileTest {
 
 		writer = new RdbWriter(destination) {
 			@Override
-			public long getDataRows() {
+			public long getDataRowCount() {
 				return 6;
 			}
 		};
@@ -106,7 +106,7 @@ class BuildRdbFileTest {
 		ResultObject res = builder.apply(req);
 
 		// ASSERTIONS
-		assertEquals(4, writer.getHeaderRows(), "The header should be written in the RDB file builder.");
+		assertEquals(4, writer.getHeaderRowCount(), "The header should be written in the RDB file builder.");
 		assertEquals(6, res.getCount(), "The result object should contain the number of rows written.");
 		assertTrue(res.getMessage().contains(FILENM), "The result object should contain the filename placed in S3.");
 		Mockito.verify(mockDao, Mockito.atLeastOnce()).sendDiscreteGroundWater(stateAsList, writer, mockAqDao.getParameters());
@@ -155,7 +155,7 @@ class BuildRdbFileTest {
 		assertThrows(RuntimeException.class, ()->builder.apply(req) );
 
 		// ASSERTIONS
-		assertEquals(0, writer.getHeaderRows(), "The header should NOT be written in the RDB file builder for bad location folder.");
+		assertEquals(0, writer.getHeaderRowCount(), "The header should NOT be written in the RDB file builder for bad location folder.");
 		Mockito.verify(mockDao, Mockito.never()).sendDiscreteGroundWater(stateAsList, writer, getParameterList());
 		Mockito.verify(mockS3b, Mockito.never()).getWriter();
 		Mockito.verify(mockS3b, Mockito.never()).close();
@@ -202,7 +202,7 @@ class BuildRdbFileTest {
 		assertThrows(RuntimeException.class, ()->builder.apply(req), "IOE converted to Runtime");
 
 		// ASSERTIONS
-		assertEquals(0, writer.getHeaderRows(), "The header should NOT be written in the RDB file builder for bad location folder.");
+		assertEquals(0, writer.getHeaderRowCount(), "The header should NOT be written in the RDB file builder for bad location folder.");
 		Mockito.verify(mockLoc, Mockito.atLeastOnce()).toStates(STATE);
 		Mockito.verify(mockLoc, Mockito.atLeastOnce()).filenameDecorator(STATE);
 		Mockito.verify(mockS3b, Mockito.atLeastOnce()).getWriter();
@@ -243,7 +243,7 @@ class BuildRdbFileTest {
 		// ASSERTIONS
 		assertEquals(-1, res.getCount());
 		assertEquals("TESTING", res.getMessage());
-		assertEquals(0, writer.getHeaderRows());
+		assertEquals(0, writer.getHeaderRowCount());
 		Mockito.verify(mockLoc, Mockito.atLeastOnce()).getLocationFolders();
 		Mockito.verify(mockLoc, Mockito.atMostOnce()).getLocationFolders();
 		Mockito.verify(mockLoc, Mockito.never()).toStates(STATE);

--- a/src/test/java/gov/usgs/wma/waterdata/groundwater/DiscreteGroundWaterDaoIT.java
+++ b/src/test/java/gov/usgs/wma/waterdata/groundwater/DiscreteGroundWaterDaoIT.java
@@ -103,7 +103,7 @@ public class DiscreteGroundWaterDaoIT {
 		destination.close();
 
 		// ASSERT row count
-		assertEquals(12, writer.getDataRows());
+		assertEquals(12, writer.getDataRowCount());
 	}
 	@DatabaseSetup(connection="observation",
 			value="classpath:/testData/")
@@ -119,7 +119,7 @@ public class DiscreteGroundWaterDaoIT {
 		destination.close();
 
 		// ASSERT row count
-		assertEquals(2, writer.getDataRows());
+		assertEquals(2, writer.getDataRowCount());
 	}
 	@DatabaseSetup(connection="observation",
 			value="classpath:/testData/")
@@ -135,7 +135,7 @@ public class DiscreteGroundWaterDaoIT {
 		destination.close();
 
 		// ASSERT row count
-		assertEquals(14, writer.getDataRows());
+		assertEquals(14, writer.getDataRowCount());
 	}
 	@DatabaseSetup(connection="observation",
 			value="classpath:/testData/")

--- a/src/test/java/gov/usgs/wma/waterdata/groundwater/DiscreteGroundWaterRowHandlerTest.java
+++ b/src/test/java/gov/usgs/wma/waterdata/groundwater/DiscreteGroundWaterRowHandlerTest.java
@@ -8,14 +8,11 @@ import java.io.Writer;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
-import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.Month;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -121,6 +118,6 @@ class DiscreteGroundWaterRowHandlerTest {
 		assertTrue(writtenValue.contains("\tD\t"));
 		assertTrue(writtenValue.contains("\t30210")); // last value
 
-		assertEquals(1, rdbWriter.getDataRows());
+		assertEquals(1, rdbWriter.getDataRowCount());
 	}
 }


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

'null' String is no longer used for null values - empty string is used instead
-----------
Ref: https://internal.cida.usgs.gov/jira/browse/IOW-683
* Improved and more deterministic testing for output values
* RdbWriter has more readable row count methods
* Added test specifically for null/empty values
* Updated readme w/ additional details on testing (missing a db)

Description
-----------
If no JIRA ticket is referenced, describe the changes made. Note anything that you want the reviewers to know while
reviewing your pull request

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial